### PR TITLE
[Fix] 글 수정할 때 태그에 콤마, 따옴표가 추가돼서 저장되는 현상 수정

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -159,7 +159,7 @@ TAGGIT_CASE_INSENSITIVE = True
 
 # django-taggit customization (config/utils.py 참고)
 TAGGIT_TAGS_FROM_STRING = 'config.utils.custom_tag_string'
-
+TAGGIT_STRING_FROM_TAGS = 'config.utils.space_joiner'
 
 # -------- allauth --------
 ## secret

--- a/config/utils.py
+++ b/config/utils.py
@@ -6,3 +6,8 @@ def custom_tag_string(tag_string):
     if not tag_string:
         return []
     return tag_string.split()
+
+
+# 수정 시 폼에 들어가는 태그 데이터들을 공백으로 구분하게
+def space_joiner(tags):
+    return ' '.join(t.name for t in tags)


### PR DESCRIPTION
- 글 수정할 때 태그에 콤마, 따옴표가 추가돼서 저장되는 현상 수정